### PR TITLE
Fixed prefit resids.  Added other options capability.  Whitespace.

### DIFF
--- a/tempo_utils.py
+++ b/tempo_utils.py
@@ -247,9 +247,9 @@ class toalist(list):
             return numpy.array([t.res.res_phase for t in self if t.is_toa()])
     def get_prefit(self,units='us'):
         if units=='us':
-            return numpy.array([t.res.res_us for t in self if t.is_toa()])
+            return numpy.array([t.res.prefit_us for t in self if t.is_toa()])
         elif units=='phase':
-            return numpy.array([t.res.res_phase for t in self if t.is_toa()])
+            return numpy.array([t.res.prefit_phase for t in self if t.is_toa()])
     def get_resid_err(self):
         return numpy.array([t.res.err_us for t in self if t.is_toa()])
     def get_freq(self):


### PR DESCRIPTION
The prefit residuals in resid2.tmp are actually in phase rather than in time.  This fixes that and adds a prefit-phase option as well.  Added a get_prefit method to get them.

Also, added the option for passing "other options" to tempo.  That's useful if you want to use "-ni/-no", for instance (although note that you need an absolute path for those given that tempo is called in a temp directory.

Finally, end of line whitespace was automatically removed by my editor (playing with atom.io -- pretty slick).
