### PR TITLE
Added GLS data covariance matrix file support.

### DIFF
--- a/tempo_utils.py
+++ b/tempo_utils.py
@@ -467,12 +467,10 @@ def run_tempo(toas, parfile, show_output=False,
             if os.path.exists(dcovfile): # See if dcovfile already exists
                 shutil.copy(dcovfile,os.path.basename(dcovfile))
                 if not any([l.startswith('DCOVFILE') for l in lines]):
-                    lines.append('DCOVFILE ' + os.path.basename(dcovfile) + '\n')
-            else: # dcovfile doesn't exist, so we will have tempo make it.
+                    open("pulsar.par",'a').writelines('DCOVFILE ' + os.path.basename(dcovfile) + '\n')
+            else: # dcovfile doesn't exist, so have tempo make it.
                 tempo_args += " -C"
                 created_dcovfile = True
-                if any([l.startswith('DCOVFILE') for l in lines]):
-                    lines = [l for l in lines if not l.startswith("DCOVFILE")]
         cmd = "tempo " + tempo_args + " -f pulsar.par pulsar.toa"
         if show_output==False:
             cmd += " > /dev/null"


### PR DESCRIPTION
GLS dcovfile support has been added to run_tempo tempo_utils.py. The name of the file can be passed to run_tempo using the variable dcovfile. If the file doesn't exist, run_tempo will create it. If the file exists, it is copied into the directory and the DCOVFILE line is inserted into the par file.
